### PR TITLE
Initialize multilib on isMultiPaper call

### DIFF
--- a/src/main/java/com/github/puregero/multilib/MultiLib.java
+++ b/src/main/java/com/github/puregero/multilib/MultiLib.java
@@ -35,7 +35,7 @@ public class MultiLib {
     }
 
     public static boolean isMultiPaper() {
-        return !(multiLib instanceof BukkitImpl);
+        return !(get() instanceof BukkitImpl);
     }
     /**
      * Returns whether the chunk is running on an external server or not.


### PR DESCRIPTION
isMultiPaper always returns true when invoked before initialization(get() call)